### PR TITLE
Client Socket Disconnection

### DIFF
--- a/src/Infrastructure/Client/Client.php
+++ b/src/Infrastructure/Client/Client.php
@@ -103,6 +103,14 @@ class Client implements ClientInterface
 
         $buffer = '';
         while (true) {
+            // Check if the socket was closed.
+            if (feof($this->socket)) {
+                $this->shutdown();
+
+                // @TODO: Construct a more descriptive error.
+                return new Result(null);
+            }
+
             $data = fread($this->socket, 1024);
             if ($data === false) {
                 $this->shutdown();


### PR DESCRIPTION
The client was not checking if the socket was remotely closed by the Kairoi server before attempting to send a query, causing an infinite wait when sending then reading the response.

* Handle the case when the client's socket is remotely closed